### PR TITLE
[PROD][KAIZEN-0] håndtere system-ident fra sf

### DIFF
--- a/app/src/main/kotlin/no/nav/henvendelse/service/dialog/LegacyHenvendelseTyper.kt
+++ b/app/src/main/kotlin/no/nav/henvendelse/service/dialog/LegacyHenvendelseTyper.kt
@@ -28,6 +28,7 @@ enum class LegacyHenvendelseTyper(val behandlingsType: String) {
                     when (melding.fra.identType) {
                         MeldingFraDTO.IdentType.AKTORID -> if (erForsteMelding) SPORSMAL_SKRIFTLIG else SVAR_SBL_INNGAAENDE
                         MeldingFraDTO.IdentType.NAVIDENT -> if (erForsteMelding) SPORSMAL_MODIA_UTGAAENDE else SVAR_SKRIFTLIG
+                        MeldingFraDTO.IdentType.SYSTEM -> SVAR_SKRIFTLIG
                     }
                 }
             }

--- a/tjenestespesifikasjoner/sf-henvendelse/src/main/resources/openapi.json
+++ b/tjenestespesifikasjoner/sf-henvendelse/src/main/resources/openapi.json
@@ -559,7 +559,7 @@
         "properties": {
           "identType": {
             "type": "string",
-            "enum": ["NAVIDENT", "AKTORID"],
+            "enum": ["NAVIDENT", "AKTORID", "SYSTEM"],
             "description": "Type ident for relatert avsender",
             "example": "NAVIDENT"
           },


### PR DESCRIPTION
noen meldinger vil autogeneres av SF, men vi ønsker ikke at disse skal påvirke visningen i gosys.

Vi finner derfor siste meldinger som ikke har IdentType.SYSTEM og bruker verdiene derifra
