### PR TITLE
[OPP-1490] Skifte pub fra docker til ghcr.io

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ name: Build, push, and deploy
 on: [push]
 
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/henvendelse-api-dialogv1:${{ github.sha }}
+  IMAGE: ghcr.io/${{ github.repository }}/henvendelse-api-dialogv1:${{ github.sha }}
   CI: true
   TZ: Europe/Oslo
 
@@ -38,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mvn -P ci -B package -DskipTests
-          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
           docker build --tag ${IMAGE} .
           docker push ${IMAGE}
 


### PR DESCRIPTION
docker.pkg.github.com er deprecated, erstattet med ghcr.io